### PR TITLE
Optimized equals method

### DIFF
--- a/src/main/java/com/cedricmartens/hexmap/coordinate/Point.java
+++ b/src/main/java/com/cedricmartens/hexmap/coordinate/Point.java
@@ -24,8 +24,8 @@ public class Point
     public boolean equals(Object o)
     {
         Point p = (Point)o;
-        return Math.round(p.x * 100.0)/100.0 == Math.round(this.x * 100.0)/100.0
-                && Math.round(p.y * 100.0)/100.0 == Math.round(this.y * 100.0)/100.0 ;
+        return Math.round(p.x * 100.0) == Math.round(this.x * 100.0)
+                && Math.round(p.y * 100.0) == Math.round(this.y * 100.0);
     }
 
     @Override


### PR DESCRIPTION
Removed useless division and implicit casting to equals method

Division on both sides is not required when the only purpose is comparing

Plus, Math.round returns a long wwhen used with a double. Dividing this long by a double only leads to an extra useless conversion. See docs for more info on Math.round https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#i55